### PR TITLE
fixed a UI Thread checker error on the new iphones

### DIFF
--- a/Swipeable-View-Stack/SampleSwipeableCard.swift
+++ b/Swipeable-View-Stack/SampleSwipeableCard.swift
@@ -19,8 +19,8 @@ class SampleSwipeableCard: SwipeableCardViewCard {
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var backgroundContainerView: UIView!
 
-    /// Core Motion Manager
-    private let motionManager = CMMotionManager()
+    /// Core Motion Manager - removing the coremotion mangaer fixes several UI Thread checker erros on ios 12 + with the xs xr and xs max
+    //private let motionManager = CMMotionManager()
 
     /// Shadow View
     private weak var shadowView: UIView?


### PR DESCRIPTION
removing the coremotion manger fixes several UI Thread checker error on ios 12 + with the xs xr and xs max. I have tested this fix and it is stable on my devices but I would recommend further testing.